### PR TITLE
cvc tooltip fix

### DIFF
--- a/app/design/frontend/base/default/template/paymill/payment/form/creditcard.phtml
+++ b/app/design/frontend/base/default/template/paymill/payment/form/creditcard.phtml
@@ -32,7 +32,7 @@
         </div>
     </li>
     <li>
-        <label for="<?php echo $_code ?>_cvc"><?php echo $this->__("paymill_Cvc") ?></label><span class="tooltip" title="<?php echo $this->__('paymill_cvc_tooltip'); ?>">?</span>
+        <label for="<?php echo $_code ?>_cvc"><?php echo $this->__("paymill_Cvc") ?></label><span class="tooltip cvv-what-is-this" title="<?php echo $this->__('paymill_cvc_tooltip'); ?>">?</span>
         <div class="input-box">
             <input value="<?php echo $this->getPaymentEntry($_code, 'cvc'); ?>" type="text" id="<?php echo $_code ?>_cvc" class="input-text paymill-validate-cc-cvc"/>
         </div>


### PR DESCRIPTION
magento (i'm on 1.8.1) uses the `cvv-what-is-this` class to register the click event on the cvc icon in order to show the tooltip.
