### PR TITLE
PaymillFrame is called with static german locale

### DIFF
--- a/app/design/frontend/base/default/template/paymill/payment/form/creditcard_form.phtml
+++ b/app/design/frontend/base/default/template/paymill/payment/form/creditcard_form.phtml
@@ -35,7 +35,7 @@
         <li>
             <label></label>
             <div class="input-box">
-                <button type="button" onclick="paymillCreditcard.methodInstance.openPaymillFrame('de');"><?php echo $this->__("paymill_change"); ?></button>
+                <button type="button" onclick="paymillCreditcard.methodInstance.openPaymillFrame('<?php echo substr(Mage::app()->getLocale()->getLocaleCode(), 0, 2); ?>');"><?php echo $this->__("paymill_change"); ?></button>
             </div>
         </li>
     </div>


### PR DESCRIPTION
The openPaymillFrame method always returns a German form when we want to change the credit card data.